### PR TITLE
Unobserve only once, otherwise Edge throws a TypeMismatchError

### DIFF
--- a/src/IntersectionElement.js
+++ b/src/IntersectionElement.js
@@ -41,13 +41,19 @@ export default class IntersectionElement extends React.Component<Props> {
       this.observe(this.node, (entry: IntersectionObserverEntry) => {
         const { onChange, once } = this.props;
         onChange(entry);
-        if (once && entry.isIntersecting) this.unobserve(this.node);
+        if (this.node && once && entry.isIntersecting) {
+          this.unobserve(this.node);
+          delete this.node;
+        }
       });
     }
   }
 
   componentWillUnmount() {
-    this.unobserve(this.node);
+    if (this.node) {
+      this.unobserve(this.node);
+      delete this.node;
+    }
   }
 
   render() {


### PR DESCRIPTION
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12577586/

While Chrome and Firefox don't crash, I think it's still useful to only call unobserve once. Note that the callback (`onChange`) may still be invoked multiple times, I did not fix that.